### PR TITLE
Add color and brightness to `getDevice`

### DIFF
--- a/lib/data-transfomers/index.js
+++ b/lib/data-transfomers/index.js
@@ -8,6 +8,8 @@ const transformRawDeviceData = (rawDeviceData) => {
   };
 
   device.on = !!get(rawDeviceData, '3311.[0].5850', 0);
+  device.color = get(rawDeviceData, '3311.[0].5706');
+  device.brightness = get(rawDeviceData, '3311.[0].5851');
 
   return device;
 };


### PR DESCRIPTION
Hi,

Fairly trivial, but just so we can pick up the appropriate preset color RGB values for subsequent settings.