### PR TITLE
Add transition time in tenths of a second for color, brightness (and state?)

### DIFF
--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -40,6 +40,10 @@ class CoapCommandBuilder {
       modifier[5851] = operation.brightness;
     }
 
+    if (!isUndefined(operation.transitionTime)) {
+      modifier[5712] = operation.transitionTime;
+    }
+
     let e = '';
     if (type === 'device') {
       e = `'{"3311":[${JSON.stringify(modifier)}]}'`;


### PR DESCRIPTION
Hi,

Sorry for the quickly repeated pull, but I just found this in `pytradfri` and it's a nice bit.  Add `transitionTime` parameter, eg. `transitionTime=10` to a device colour or brightness change and it'll animate it smoothly.  I'm not sure what attributes it applies to -- on and off don't seem to be affected, and no idea about groups -- so I haven't documented it properly.

Tom