### PR TITLE
Added support for colorX and colorY parameters.

### DIFF
--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -46,6 +46,14 @@ class CoapCommandBuilder {
       modifier[5706] = operation.color;
     }
 
+    if (!isUndefined(operation.colorX)) {
+      modifier[5709] = operation.colorX;
+    }
+
+    if (!isUndefined(operation.colorY)) {
+      modifier[5710] = operation.colorY;
+    }
+
     if (!isUndefined(operation.brightness)) {
       modifier[5851] = operation.brightness;
     }


### PR DESCRIPTION
A very simple update/change adding two more parameters (colorX and colorY) which the lamps use for the xyY color format, allowing for much finer control over the color. By default, the lamps will only accept the hex codes which are predefined as presets by Ikea, but this allows for a much wider range of colors.